### PR TITLE
Delay file_exists from setDBDat to downloadData

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -632,10 +632,6 @@ class Parser
      */
     protected function setDBdat()
     {
-        if (!file_exists($this->data_dir)) {
-            $this->debug('Data dir not found'); 
-            return false;
-        }
         if (!$this->dbdat) {
            $this->debug("Open DB file: ".$this->data_dir."/udgerdb.dat");
            if(!empty($this->access_key) && $this->autoUpdate === true) {
@@ -697,8 +693,13 @@ class Parser
      */
     protected function downloadData($version = "")
     {     
-         $status = false;
+        $status = false;
         
+        if (!file_exists($this->data_dir)) {
+            $this->debug('Data dir not found');
+            return $status;
+        }
+
         // support for fopen is needed
         if (!ini_get('allow_url_fopen')) {
             $this->debug('php fopen unavailable, download the data manually from http://data.udger.com/');


### PR DESCRIPTION
setDBDat only cares if there's a DB connection or not, not the state of
the file. Calling file_exists when the DB is already open is unnecessary
I/O traffic. Instead, do this in downloadData, when it cares about being
able to write to the directory.