### PR TITLE
replace split to explode

### DIFF
--- a/src/Helper/IP.php
+++ b/src/Helper/IP.php
@@ -53,7 +53,7 @@ class IP implements IPInterface{
       $ipStr = substr(preg_replace("/([A-f0-9]{4})/", "$1:", $hex['hex']), 0, -1);
       
       $ipIntArray = array();
-      $ipStrArray = split(":", $ipStr);
+      $ipStrArray = explode(":", $ipStr);
       
       foreach ($ipStrArray as &$value) {
         $ipIntArray[] = hexdec($value);


### PR DESCRIPTION
split deprecated and removed in php7